### PR TITLE
Fix the consistency issue between the prover transcript and the verifier transcript

### DIFF
--- a/src/curve/curve25519/g1.rs
+++ b/src/curve/curve25519/g1.rs
@@ -25,11 +25,11 @@ impl ModelParameters for Parameters {
 }
 
 impl TEModelParameters for Parameters {
-    /// COEFF_A = 973328/2 
+    /// COEFF_A = 973328/2
     ///         = 486664
     const COEFF_A: Fq = field_new!(Fq, "486664");
 
-    /// COEFF_D = 973320/2 
+    /// COEFF_D = 973320/2
     ///         = 486660
     const COEFF_D: Fq = field_new!(Fq, "486660");
 

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -511,7 +511,7 @@ impl<G: AffineCurve, T: BorrowMut<Transcript>> Verifier<G, T> {
             .collect();
 
         let r: G::ScalarField = <Transcript as TranscriptProtocol<G>>::challenge_scalar(
-            self.transcript.borrow_mut(),
+            &mut self.transcript.borrow_mut().clone(),
             b"r",
         );
 


### PR DESCRIPTION
In Noah, it is important that the prover and the verifier are using the same transcript, as it will also affect the rest of the protocol.

This PR fixes an issue that was brought in by #4. The verifier takes the final challenge `r` without changing the existing transcript. 