### PR TITLE
Reduce the number of patches used for arkworks-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,10 +130,5 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", branch = "release-0.4-fix-field-test" }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", branch = "release-0.4-fix-field-test" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra", branch = "release-0.4-fix-field-test" }
-ark-std = { git = "https://github.com/arkworks-rs/std", branch = "release-0.4" }
-ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", branch = "release-0.4-fix-field-test" }
 ark-secp256k1 = { git = "https://github.com/arkworks-rs/curves" }
 ark-secq256k1 = { git = "https://github.com/arkworks-rs/curves" }


### PR DESCRIPTION
We will need to wait for another alpha release for curves. Before that, we remove the patches related to algebra.